### PR TITLE
Fix: Verbesserung der Fehlerbehandlung für Wetter-API-Datenabruf

### DIFF
--- a/src/main/java/de/htw_berlin/prose/SimpleWeatherSentence.java
+++ b/src/main/java/de/htw_berlin/prose/SimpleWeatherSentence.java
@@ -55,9 +55,23 @@ public class SimpleWeatherSentence implements Sentence {
             HttpRequest request = HttpRequest.newBuilder().uri(URI.create(url)).build();
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
 
-            // Prüfe den HTTP-Statuscode, bevor das Ergebnis verarbeitet wird
-            if (response.statusCode() != 200) {
-                return String.format("Wetterdaten für %s konnten nicht abgerufen werden (HTTP %d)", city, response.statusCode());
+            // Prüfe den HTTP-Statuscode und gib spezifische Fehlermeldungen aus
+            switch (response.statusCode()) {
+                case 200:
+                    // Erfolgreiche Antwort - weiter mit der Verarbeitung
+                    break;
+                case 401:
+                    return String.format("Ungültiger oder fehlender API-Key (HTTP 401)");
+                case 403:
+                    return String.format("Zugriff verweigert - möglicherweise ungültiger API-Key oder fehlende Berechtigung (HTTP 403)");
+                case 404:
+                    return String.format("Ressource nicht gefunden - Stadt '%s' existiert möglicherweise nicht oder API-Endpoint ist ungültig (HTTP 404)", city);
+                case 429:
+                    return String.format("API-Rate-Limit überschritten - zu viele Anfragen (HTTP 429)");
+                case 500:
+                    return String.format("Server-Fehler beim Wetterdienst (HTTP 500)");
+                default:
+                    return String.format("Wetterdaten für %s konnten nicht abgerufen werden (HTTP %d)", city, response.statusCode());
             }
 
             JSONObject jsonResponse = new JSONObject(response.body());

--- a/src/main/java/de/htw_berlin/prose/SimpleWeatherSentence.java
+++ b/src/main/java/de/htw_berlin/prose/SimpleWeatherSentence.java
@@ -55,6 +55,11 @@ public class SimpleWeatherSentence implements Sentence {
             HttpRequest request = HttpRequest.newBuilder().uri(URI.create(url)).build();
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
 
+            // Prüfe den HTTP-Statuscode, bevor das Ergebnis verarbeitet wird
+            if (response.statusCode() != 200) {
+                return String.format("Wetterdaten für %s konnten nicht abgerufen werden (HTTP %d)", city, response.statusCode());
+            }
+
             JSONObject jsonResponse = new JSONObject(response.body());
             double temperature = jsonResponse.getJSONObject("main").getDouble("temp");
 


### PR DESCRIPTION
## Update 30.06.2025, 19.29: Erweiterte HTTP-Statuscode-Behandlung
Die Fehlerbehandlung wurde um spezifische HTTP-Statuscodes erweitert:

Implementierte Statuscodes:
- 401 Unauthorized: Ungültiger oder fehlender API-Key
- 403 Forbidden: Zugriff verweigert (meist API-Key-Berechtigung)
- 404 Not Found: Ressource nicht gefunden (ungültige Stadt oder falscher Endpoint)
- 429 Too Many Requests: API-Rate-Limit überschritten
- 500 Internal Server Error: Server-Fehler beim Wetterdienst

Erweiterte Tests:
- 401 testen: Ungültigen API-Key setzen oder API-Key entfernen
- 403 testen: Abgelaufenen API-Key nutzen
- 404 testen: Nicht existierende Stadt verwenden (z.B. "NowhereLand") oder URL-Endpoint ändern
- 429 testen: Viele API-Aufrufe schnell hintereinander senden (Loop mit 100+ Requests)
- 500 testen: Ungültigen API-Endpoint verwenden (z.B. /invalid_endpoint statt /weather)

Jeder Statuscode liefert nun eine spezifische, benutzerfreundliche Fehlermeldung statt einer generischen Exception.


## Description

Dieses Pull Request verbessert die Fehlerbehandlung in der Methode SimpleWeatherSentence.get().
Bisher wurde die HTTP-Antwort der OpenWeather-API nicht auf einen erfolgreichen Statuscode geprüft, bevor das Ergebnis verarbeitet wurde. Das konnte zu Ausnahmen führen, wenn z.B. der API-Key ungültig war oder eine unbekannte Stadt abgefragt wurde.
Mit diesem Fix wird nun der HTTP-Statuscode geprüft und bei Fehlern eine verständliche Fehlermeldung zurückgegeben.

## Related Issues

Fixes #3

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update (e.g., README, Javadoc)
- [ ] Test improvement
- [ ] Other (please describe): __________

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code, especially in complex areas
- [ ] I have updated the documentation (if applicable)
- [ ] I have added or updated tests (if applicable)
- [ ] All new and existing tests pass
- [x] I have verified the application runs correctly
- [ ] The CI pipeline passes (e.g., GitHub Actions)

## How to Test

Provide clear instructions for reviewers on how to test the changes:
- Step 1: Stelle sicher, dass ein gültiger OpenWeather-API-Key als Umgebungsvariable gesetzt ist.
- Step 2: Starte das Programm wie gewohnt. Es sollten für gültige Städte die aktuellen Temperaturen angezeigt werden.
- Step 3: Teste einen ungültigen API-Key oder eine nicht existierende Stadt (z.B. "NowhereLand").
→ Es sollte eine verständliche Fehlermeldung wie
Wetterdaten für NowhereLand konnten nicht abgerufen werden (HTTP 404)
oder
Wetterdaten für Berlin konnten nicht abgerufen werden (HTTP 401)
erscheinen.